### PR TITLE
Extracting Assert Logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 composer.lock
 vendor
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "hamcrest/hamcrest-php": "^2.0",
         "illuminate/support": "^5.5",
         "myclabs/php-enum": "^1.5",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "~8.0.0",
         "symfony/var-dumper": "^4.0",
         "dms/phpunit-arraysubset-asserts": "^0.1.0"
     },

--- a/src/Assertions/Assert.php
+++ b/src/Assertions/Assert.php
@@ -2,18 +2,21 @@
 
 namespace Muzzle\Assertions;
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Muzzle\CliFormatter;
-use PHPUnit\Framework\Assert as PHPUnit;
+use PHPUnit\Framework\Assert as PHPUnitAssert;
 use function Muzzle\is_regex;
 
-class Assert
+class Assert extends PHPUnitAssert
 {
+
+    use ArraySubsetAsserts;
 
     public static function assertArraysMatch(iterable $expected, array $actual) : void
     {
 
         foreach ($expected as $key => $value) {
-            PHPUnit::assertArrayHasKey(
+            static::assertArrayHasKey(
                 $key,
                 $actual,
                 "Did not find the expected key [{$key}] in the provided content:" . PHP_EOL
@@ -21,12 +24,12 @@ class Assert
             );
 
             if (is_regex($value)) {
-                PHPUnit::assertIsScalar(
+                static::assertIsScalar(
                     $actual[$key],
                     "Cannot match pattern [{$value}] against non-string value:" . PHP_EOL
                     . CliFormatter::format($actual[$key])
                 );
-                PHPUnit::assertRegExp($value, $actual[$key]);
+                static::assertRegExp($value, $actual[$key]);
                 continue;
             }
 
@@ -35,7 +38,7 @@ class Assert
                 continue;
             }
 
-            PHPUnit::assertEquals(
+            static::assertEquals(
                 $value,
                 $actual[$key],
                 "The expected value for [{$key}]" . PHP_EOL

--- a/src/Assertions/BodyMatches.php
+++ b/src/Assertions/BodyMatches.php
@@ -3,7 +3,6 @@
 namespace Muzzle\Assertions;
 
 use Muzzle\Messages\AssertableRequest;
-use PHPUnit\Framework\Assert as PHPUnit;
 use Psr\Http\Message\StreamInterface;
 use function Muzzle\is_json;
 use function Muzzle\is_regex;
@@ -26,7 +25,7 @@ class BodyMatches implements Assertion
     {
 
         if (! is_json($this->body) and is_regex($this->body)) {
-            PHPUnit::assertRegExp($this->body, (string) $actual->getBody());
+            Assert::assertRegExp($this->body, (string) $actual->getBody());
             return;
         }
 

--- a/src/Assertions/MethodMatches.php
+++ b/src/Assertions/MethodMatches.php
@@ -3,7 +3,6 @@
 namespace Muzzle\Assertions;
 
 use Muzzle\Messages\AssertableRequest;
-use PHPUnit\Framework\Assert as PHPUnit;
 
 class MethodMatches implements Assertion
 {
@@ -22,7 +21,7 @@ class MethodMatches implements Assertion
     public function __invoke(AssertableRequest $actual) : void
     {
 
-        PHPUnit::assertArrayHasKey(
+        Assert::assertArrayHasKey(
             $actual->getMethod(),
             array_flip(array_map('strtoupper', $this->methods)),
             sprintf(

--- a/src/Assertions/QueryEquals.php
+++ b/src/Assertions/QueryEquals.php
@@ -4,7 +4,6 @@ namespace Muzzle\Assertions;
 
 use Muzzle\CliFormatter;
 use Muzzle\Messages\AssertableRequest;
-use PHPUnit\Framework\Assert as PHPUnit;
 
 class QueryEquals implements Assertion
 {
@@ -27,7 +26,7 @@ class QueryEquals implements Assertion
         parse_str($actual->getUri()->getQuery(), $query);
         ksort($query);
         ksort($expected);
-        PHPUnit::assertEquals(
+        Assert::assertEquals(
             $expected,
             $query,
             'The expected query' . PHP_EOL

--- a/src/Assertions/UriPathMatches.php
+++ b/src/Assertions/UriPathMatches.php
@@ -7,7 +7,6 @@ use GuzzleHttp\Psr7\UriResolver;
 use Illuminate\Support\Str;
 use Muzzle\Messages\AssertableRequest;
 use Muzzle\Muzzle;
-use PHPUnit\Framework\Assert as PHPUnit;
 use function Muzzle\is_regex;
 
 class UriPathMatches implements Assertion
@@ -31,7 +30,7 @@ class UriPathMatches implements Assertion
             return;
         }
 
-        PHPUnit::assertTrue(Str::is($expectedPath, $actual->getUri()->getPath()), sprintf(
+        Assert::assertTrue(Str::is($expectedPath, $actual->getUri()->getPath()), sprintf(
             'The request path [%s] does not match the expectation [%s].',
             urldecode($actual->getUri()->getPath()),
             $expectedPath
@@ -50,7 +49,7 @@ class UriPathMatches implements Assertion
     private function assertMatchesPattern(AssertableRequest $actual, string $expectedPath) : void
     {
 
-        PHPUnit::assertRegExp($expectedPath, $actual->getUri()->getPath(), sprintf(
+        Assert::assertRegExp($expectedPath, $actual->getUri()->getPath(), sprintf(
             'The request path [%s] does not match the expected pattern [%s].',
             urldecode($actual->getUri()->getPath()),
             $expectedPath

--- a/src/Messages/AssertableRequest.php
+++ b/src/Messages/AssertableRequest.php
@@ -2,11 +2,12 @@
 
 namespace Muzzle\Messages;
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Exception;
 use GuzzleHttp\Psr7;
 use Illuminate\Support\Str;
+use Muzzle\Assertions\Assert;
 use Muzzle\CliFormatter;
-use PHPUnit\Framework\Assert as PHPUnit;
 use Psr\Http\Message\RequestInterface;
 
 class AssertableRequest implements RequestInterface
@@ -27,7 +28,7 @@ class AssertableRequest implements RequestInterface
     public function assertHeader($headerName, $value = null)
     {
 
-        PHPUnit::assertTrue(
+        Assert::assertTrue(
             $this->hasHeader($headerName),
             "Header [{$headerName}] not present on request."
         );
@@ -46,7 +47,7 @@ class AssertableRequest implements RequestInterface
                 implode(', ', $expected)
             );
 
-            self::assertArraySubset($expected, $actual, $message);
+            ArraySubsetAsserts::assertArraySubset($expected, $actual, $message);
         }
 
         return $this;
@@ -61,7 +62,7 @@ class AssertableRequest implements RequestInterface
     public function assertRequestTarget($target)
     {
 
-        PHPUnit::assertEquals($target, $this->getRequestTarget());
+        Assert::assertEquals($target, $this->getRequestTarget());
 
         return $this;
     }
@@ -75,7 +76,7 @@ class AssertableRequest implements RequestInterface
     public function assertMethod(string $method)
     {
 
-        PHPUnit::assertEquals(
+        Assert::assertEquals(
             strtoupper($method),
             $this->getMethod(),
             sprintf(
@@ -98,7 +99,7 @@ class AssertableRequest implements RequestInterface
     public function assertUriScheme(string $scheme)
     {
 
-        PHPUnit::assertEquals($scheme, $this->getUri()->getScheme());
+        Assert::assertEquals($scheme, $this->getUri()->getScheme());
 
         return $this;
     }
@@ -112,7 +113,7 @@ class AssertableRequest implements RequestInterface
     public function assertUriAuthority(string $authority)
     {
 
-        PHPUnit::assertEquals($authority, $this->getUri()->getAuthority());
+        Assert::assertEquals($authority, $this->getUri()->getAuthority());
 
         return $this;
     }
@@ -126,7 +127,7 @@ class AssertableRequest implements RequestInterface
     public function assertUriUserInfo(string $userInfo)
     {
 
-        PHPUnit::assertEquals($userInfo, $this->getUri()->getUserInfo());
+        Assert::assertEquals($userInfo, $this->getUri()->getUserInfo());
 
         return $this;
     }
@@ -140,7 +141,7 @@ class AssertableRequest implements RequestInterface
     public function assertUriHost(string $host)
     {
 
-        PHPUnit::assertEquals($host, $this->getUri()->getHost());
+        Assert::assertEquals($host, $this->getUri()->getHost());
 
         return $this;
     }
@@ -154,7 +155,7 @@ class AssertableRequest implements RequestInterface
     public function assertUriPort(?int $port = null)
     {
 
-        PHPUnit::assertEquals($port, $this->getUri()->getPort());
+        Assert::assertEquals($port, $this->getUri()->getPort());
 
         return $this;
     }
@@ -170,7 +171,7 @@ class AssertableRequest implements RequestInterface
     public function assertUriPath(string $pattern)
     {
 
-        PHPUnit::assertTrue(
+        Assert::assertTrue(
             Str::is($pattern, $this->getUri()->getPath()),
             sprintf(
                 'The path [%s] does not match the expected pattern [%s].',
@@ -185,7 +186,7 @@ class AssertableRequest implements RequestInterface
     public function assertUriPathMatches(string $pattern) : self
     {
 
-        PHPUnit::assertRegExp(
+        Assert::assertRegExp(
             $pattern,
             $this->getUri()->getPath(),
             sprintf(
@@ -208,7 +209,7 @@ class AssertableRequest implements RequestInterface
     public function assertUriFragment(string $fragment)
     {
 
-        PHPUnit::assertEquals($fragment, $this->getUri()->getFragment());
+        Assert::assertEquals($fragment, $this->getUri()->getFragment());
 
         return $this;
     }
@@ -223,7 +224,7 @@ class AssertableRequest implements RequestInterface
     public function assertUriQuery(string $query)
     {
 
-        PHPUnit::assertEquals($query, $this->getUri()->getQuery());
+        Assert::assertEquals($query, $this->getUri()->getQuery());
 
         return $this;
     }
@@ -238,7 +239,7 @@ class AssertableRequest implements RequestInterface
     {
 
         $query = Psr7\parse_query($this->getUri()->getQuery());
-        PHPUnit::assertArrayHasKey($key, $query);
+        Assert::assertArrayHasKey($key, $query);
 
         return $this;
     }
@@ -253,7 +254,7 @@ class AssertableRequest implements RequestInterface
     {
 
         $query = Psr7\parse_query($this->getUri()->getQuery());
-        PHPUnit::assertArrayNotHasKey($key, $query, sprintf(
+        Assert::assertArrayNotHasKey($key, $query, sprintf(
             'Could not find [%s] in the query parameters: %s',
             $key,
             CliFormatter::format($query)
@@ -273,7 +274,7 @@ class AssertableRequest implements RequestInterface
     {
 
         $query = Psr7\parse_query($this->getUri()->getQuery());
-        self::assertArraySubset($values, $query, false, (function ($expected, $actual) {
+        ArraySubsetAsserts::assertArraySubset($values, $query, false, (function ($expected, $actual) {
 
             return 'Could not find ' . PHP_EOL
                    . CliFormatter::format($expected) . PHP_EOL
@@ -287,7 +288,7 @@ class AssertableRequest implements RequestInterface
     public function assertUriEquals(Psr7\Uri $uri)
     {
 
-        PHPUnit::assertEquals($this->getUri(), $uri, sprintf(
+        Assert::assertEquals($this->getUri(), $uri, sprintf(
             'Failed asserting %s equals %s',
             urldecode($this->getUri()),
             urldecode($uri)

--- a/src/Messages/AssertableResponse.php
+++ b/src/Messages/AssertableResponse.php
@@ -2,7 +2,7 @@
 
 namespace Muzzle\Messages;
 
-use PHPUnit\Framework\Assert as PHPUnit;
+use Muzzle\Assertions\Assert;
 
 class AssertableResponse extends DecodableResponse
 {
@@ -18,7 +18,7 @@ class AssertableResponse extends DecodableResponse
     public function assertSuccessful()
     {
 
-        PHPUnit::assertTrue(
+        Assert::assertTrue(
             $this->isSuccessful(),
             "Response status code [{$this->getStatusCode()}] is not a successful status code."
         );
@@ -37,7 +37,7 @@ class AssertableResponse extends DecodableResponse
 
         $actual = $this->getStatusCode();
 
-        PHPUnit::assertTrue(
+        Assert::assertTrue(
             $actual === $status,
             "Expected status code {$status} but received {$actual}."
         );
@@ -54,7 +54,7 @@ class AssertableResponse extends DecodableResponse
     public function assertRedirect($uri = null)
     {
 
-        PHPUnit::assertTrue(
+        Assert::assertTrue(
             $this->isRedirect(),
             "Response status code [{$this->getStatusCode()}] is not a redirect status code."
         );
@@ -62,7 +62,7 @@ class AssertableResponse extends DecodableResponse
         if (! is_null($uri)) {
             $locationTo = app('url')->to($uri);
             foreach ($this->getHeader('Location') as $location) {
-                PHPUnit::assertEqualsIgnoringCase($locationTo, $location);
+                Assert::assertEqualsIgnoringCase($locationTo, $location);
             }
         }
 
@@ -79,7 +79,7 @@ class AssertableResponse extends DecodableResponse
     public function assertHeader($headerName, $value = null)
     {
 
-        PHPUnit::assertTrue(
+        Assert::assertTrue(
             $this->hasHeader($headerName),
             "Header [{$headerName}] not present on response."
         );
@@ -93,7 +93,7 @@ class AssertableResponse extends DecodableResponse
                 implode(', ', $actual),
                 $value
             );
-            PHPUnit::assertContains($value, $actual, $message);
+            Assert::assertContains($value, $actual, $message);
         }
 
         return $this;

--- a/src/Messages/ContentAssertions.php
+++ b/src/Messages/ContentAssertions.php
@@ -2,17 +2,15 @@
 
 namespace Muzzle\Messages;
 
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Muzzle\Assertions\Assert;
 use Muzzle\CliFormatter;
-use PHPUnit\Framework\Assert as PHPUnit;
 use Psr\Http\Message\StreamInterface;
 
 trait ContentAssertions
 {
-    use ArraySubsetAsserts;
 
     /**
      * Gets the body of the message.
@@ -37,7 +35,7 @@ trait ContentAssertions
     public function assertSee($value) : self
     {
 
-        PHPUnit::assertStringContainsString($value, (string) $this->getBody());
+        Assert::assertStringContainsString($value, (string) $this->getBody());
 
         return $this;
     }
@@ -51,7 +49,7 @@ trait ContentAssertions
     public function assertSeeText($value) : self
     {
 
-        PHPUnit::assertStringContainsString($value, strip_tags((string) $this->getBody()));
+        Assert::assertStringContainsString($value, strip_tags((string) $this->getBody()));
 
         return $this;
     }
@@ -65,7 +63,7 @@ trait ContentAssertions
     public function assertDoNotSee($value) : self
     {
 
-        PHPUnit::assertStringNotContainsString($value, (string) $this->getBody());
+        Assert::assertStringNotContainsString($value, (string) $this->getBody());
 
         return $this;
     }
@@ -79,7 +77,7 @@ trait ContentAssertions
     public function assertDoNotSeeText($value) : self
     {
 
-        PHPUnit::assertStringNotContainsString($value, strip_tags((string) $this->getBody()));
+        Assert::assertStringNotContainsString($value, strip_tags((string) $this->getBody()));
 
         return $this;
     }
@@ -94,7 +92,7 @@ trait ContentAssertions
     public function assertJson(array $data) : self
     {
 
-        self::assertArraySubset(
+        Assert::assertArraySubset(
             $data,
             $this->decode(),
             false,
@@ -134,7 +132,7 @@ trait ContentAssertions
 
         $actual = json_encode(Arr::sortRecursive((array) $this->decode()));
 
-        PHPUnit::assertEquals(json_encode(Arr::sortRecursive($data)), $actual);
+        Assert::assertEquals(json_encode(Arr::sortRecursive($data)), $actual);
 
         return $this;
     }
@@ -153,7 +151,7 @@ trait ContentAssertions
         foreach (Arr::sortRecursive($data) as $key => $value) {
             $expected = substr(json_encode([$key => $value]), 1, -1);
 
-            PHPUnit::assertTrue(
+            Assert::assertTrue(
                 Str::contains($actual, $expected),
                 'Unable to find JSON fragment: ' . PHP_EOL . PHP_EOL .
                 "[{$expected}]" . PHP_EOL . PHP_EOL .
@@ -179,7 +177,7 @@ trait ContentAssertions
         foreach (Arr::sortRecursive($data) as $key => $value) {
             $expected = substr(json_encode([$key => $value]), 1, -1);
 
-            PHPUnit::assertFalse(
+            Assert::assertFalse(
                 Str::contains($actual, $expected),
                 'Found unexpected JSON fragment: ' . PHP_EOL . PHP_EOL .
                 "[{$expected}]" . PHP_EOL . PHP_EOL .
@@ -212,13 +210,13 @@ trait ContentAssertions
 
         foreach ($structure as $key => $value) {
             if (is_array($value) && $key === '*') {
-                PHPUnit::assertIsArray($responseData);
+                Assert::assertIsArray($responseData);
 
                 foreach ($responseData as $responseDataItem) {
                     $this->assertJsonStructure($structure['*'], $responseDataItem);
                 }
             } elseif (is_array($value)) {
-                PHPUnit::assertArrayHasKey($key, $responseData, sprintf(
+                Assert::assertArrayHasKey($key, $responseData, sprintf(
                     'Could not find key [%s] within data subset: %s',
                     $key,
                     CliFormatter::format($responseData)
@@ -226,7 +224,7 @@ trait ContentAssertions
 
                 $this->assertJsonStructure($structure[$key], $responseData[$key]);
             } else {
-                PHPUnit::assertArrayHasKey($value, $responseData, sprintf(
+                Assert::assertArrayHasKey($value, $responseData, sprintf(
                     'Could not find key [%s] within data subset: %s',
                     $value,
                     CliFormatter::format($responseData)
@@ -246,7 +244,7 @@ trait ContentAssertions
 
         $body = (string) $body;
         if ($body !== '') {
-            PHPUnit::assertEquals($body, (string) $this->getBody());
+            Assert::assertEquals($body, (string) $this->getBody());
         }
 
         return $this;

--- a/src/WrapsGuzzle.php
+++ b/src/WrapsGuzzle.php
@@ -4,8 +4,6 @@ namespace Muzzle;
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Muzzle\Messages\AssertableResponse;
-use OutOfBoundsException;
-use PHPUnit\Framework\Assert as PHPUnit;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;

--- a/tests/TransactionsTest.php
+++ b/tests/TransactionsTest.php
@@ -180,4 +180,12 @@ class TransactionsTest extends TestCase
 
         $this->assertSame($transactions, $instance->transactions());
     }
+
+    /** @test */
+    public function itWillThrowAnExceptionIfANonTransactionElementIsPassedInTheConstructor() : void
+    {
+
+        $this->expectException(NotATransaction::class);
+        new Transactions(['foo']);
+    }
 }

--- a/tests/WrapsGuzzleTest.php
+++ b/tests/WrapsGuzzleTest.php
@@ -2,15 +2,12 @@
 
 namespace Muzzle;
 
-use BadMethodCallException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use InvalidArgumentException;
-use OutOfBoundsException;
-use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 
 class WrapsGuzzleTest extends TestCase


### PR DESCRIPTION
## Description

This PR extracts the PHPUnit assertion logic into the `Muzzle\Assertions\Assert` class so that assertion logic can be kept to the `Assert` class. It also restricts the PHPUnit version to 8.0 for now while we wait for the 8.1 bug (https://github.com/sebastianbergmann/phpunit/issues/3599) to be resolved.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.